### PR TITLE
prevent 'rails g' command to generate unnecessary files

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,12 @@ module SpacemarketClone
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    #コントローラー生成時に不要なファイルが作成されないように設定
+    config.generators do |g|
+      g.helper false
+      g.test_framework false
+    end
+
   end
 end


### PR DESCRIPTION
# WHAT
ターミナルのコマンドでコントローラーを生成したときに、不要なファイルが生成されないように設定する

# WHY
不要なファイルが存在していると、第三者による閲覧時に混乱を生むため
