### PR TITLE
Add name,image,type column to the users table

### DIFF
--- a/db/migrate/20170516051800_add_somecolumns_to_users.rb
+++ b/db/migrate/20170516051800_add_somecolumns_to_users.rb
@@ -1,0 +1,8 @@
+class AddSomecolumnsToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :name, :string, null: false
+    add_column :users, :image, :string
+    add_column :users, :type, :integer, default: 1, null: false
+    add_index :users, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170516043719) do
+ActiveRecord::Schema.define(version: 20170516051800) do
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false
@@ -25,7 +25,11 @@ ActiveRecord::Schema.define(version: 20170516043719) do
     t.string   "last_sign_in_ip"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.string   "name",                                null: false
+    t.string   "image"
+    t.integer  "type",                   default: 1,  null: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.index ["name"], name: "index_users_on_name", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 


### PR DESCRIPTION
# WHAT
usersテーブルに以下のカラムを追加
- name
- image
- type（ゲストとホストとで権限を分けるために使用するカラム）
　※ゲスト：1（デフォルト）, ホスト：2

# WHY
ユーザー管理に必要なため

### カラム追加時のターミナル
![2017-05-16 14 45 44](https://cloud.githubusercontent.com/assets/25572309/26091492/90494fc2-3a46-11e7-964f-d5dc9b0e0648.png)

### カラム追加後のテーブルの構造
![2017-05-16 14 46 29](https://cloud.githubusercontent.com/assets/25572309/26091502/9f29f172-3a46-11e7-8e0a-0d7de2475360.png)
