### PR TITLE
Permit 'name,image,type' column as a strong parameter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,11 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :image, :type])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image, :type])
+  end
+
 end


### PR DESCRIPTION
# WHAT
usersテーブルに追加したカラムのストロングパラメーターの設定

# WHY
セキュリティ上必要なため

### 参考にしたページ
http://easyramble.com/strong-parameters-on-rails-devise.html
