### PR TITLE
Rename 'type' column to 'usertype'

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,8 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :image, :type])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image, :type])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :image, :usertype])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :image, :usertype])
   end
 
 end

--- a/db/migrate/20170516070706_rename_type_column_to_users.rb
+++ b/db/migrate/20170516070706_rename_type_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnToUsers < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :users, :type, :usertype
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170516051800) do
+ActiveRecord::Schema.define(version: 20170516070706) do
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 20170516051800) do
     t.datetime "updated_at",                          null: false
     t.string   "name",                                null: false
     t.string   "image"
-    t.integer  "type",                   default: 1,  null: false
+    t.integer  "usertype",               default: 1,  null: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["name"], name: "index_users_on_name", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree


### PR DESCRIPTION
# WHAT
usersテーブルのtypeカラムの名前をusertypeに変更。
これに伴い、deviseのストロングパラメーターの記述も修正。

# WHY
'type'は予約後で使用できないため

## 参考にしたページ
http://ruby-rails.hatenadiary.com/entry/20140810/1407634200#migration-rename-column
http://shonoooo.hatenablog.com/entry/2015/06/29/171915

### カラム名変更の際のターミナル画面
![2017-05-16 16 10 13](https://cloud.githubusercontent.com/assets/25572309/26094153/b36727e2-3a53-11e7-8115-c225d6475118.png)

