### PR TITLE
added link to the buttons in header and footer

### DIFF
--- a/app/assets/stylesheets/_top.scss
+++ b/app/assets/stylesheets/_top.scss
@@ -8,12 +8,7 @@
     width: 960px;
     margin: 0 auto;
 
-    &__menu_signup{
-      @include button();
-      float: right;
-    }
-
-    &__menu_signin{
+    &__menu_signout, &__menu_edit, &__menu_signup, &__menu_signin{
       @include button();
       float: right;
     }
@@ -90,14 +85,9 @@
         float: left;
       }
 
-      &__menu_signin{
-        @include button();
-        float: left;
-      }
-
-      &__menu_signup{
-        @include button();
-        float: left;
-      }
+    &__menu_signup, &__menu_signin{
+      @include button();
+      float: left;
+    }
   }
 }

--- a/app/views/spaces/index.html.haml
+++ b/app/views/spaces/index.html.haml
@@ -1,12 +1,19 @@
 %header#header
   .header-inner
-    = link_to 'https://www.google.co.jp/' do
-      .header-inner__menu_signup
-        新規登録
-    = link_to 'https://www.google.co.jp/' do
-      .header-inner__menu_signin
-        ログイン
-
+    - if user_signed_in?
+      = link_to destroy_user_session_path, method: :delete do
+        .header-inner__menu_signout
+          ログアウト
+      = link_to edit_user_registration_path do
+        .header-inner__menu_edit
+          登録情報編集
+    - else
+      = link_to new_user_registration_path do
+        .header-inner__menu_signup
+          新規登録
+      = link_to new_user_session_path do
+        .header-inner__menu_signin
+          ログイン
 
 %section.content
   .content__logo
@@ -60,9 +67,11 @@
   .footer-inner
     .footer-inner__logo
       = image_tag 'logo_black.png'
-    = link_to 'https://www.google.co.jp/' do
-      .footer-inner__menu_signin
-        ログイン
-    = link_to 'https://www.google.co.jp/' do
-      .footer-inner__menu_signup
-        新規登録
+    - unless user_signed_in?
+      = link_to new_user_registration_path do
+        .footer-inner__menu_signup
+          新規登録
+      = link_to new_user_session_path do
+        .footer-inner__menu_signin
+          ログイン
+


### PR DESCRIPTION
# WHAT
トップページのヘッダーとフッターの「新規登録（devise/registrations#new）」ボタンと「ログイン（devise/sessions#new）」ボタンにリンクを付与する。
また、ログイン時は「登録情報編集（devise/registrations#edit）」ボタンと「ログアウト（devise/sessions#destroy）」ボタンを表示する（ヘッダーのみ）。

# WHY
ユーザービリティ向上の為

### 実装後の画面（ログイン時）
![2017-05-16 19 10 50](https://cloud.githubusercontent.com/assets/25572309/26101795/632dcfc8-3a6d-11e7-81ae-3453c5ac9483.png)
![2017-05-16 19 11 03](https://cloud.githubusercontent.com/assets/25572309/26101802/67dc097c-3a6d-11e7-929f-55bdda2178fb.png)



### 実装後の画面（非ログイン時）
![2017-05-16 19 11 11](https://cloud.githubusercontent.com/assets/25572309/26101804/6d199b70-3a6d-11e7-8f7f-48f9eda922d9.png)
![2017-05-16 19 11 51](https://cloud.githubusercontent.com/assets/25572309/26101810/71de667c-3a6d-11e7-8948-25b7d5efc045.png)




