### PR TITLE
Create space register page in owner's dashboard

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,3 +10,4 @@
 @import "./module/host_register";
 
 @import "./module/owner_dashboards";
+@import "./module/owner_spaces-left";

--- a/app/assets/stylesheets/mixin/_mixin.scss
+++ b/app/assets/stylesheets/mixin/_mixin.scss
@@ -17,3 +17,10 @@
   line-height: 30px;
   border-radius: 2px;
 }
+
+@mixin linktext_darkgray(){
+  a:link { color: $dark-gray; }
+  a:visited { color: $dark-gray; }
+  a:hover { color: $dark-gray; }
+  a:active { color: $dark-gray; }
+}

--- a/app/assets/stylesheets/module/_owner_spaces-left.scss
+++ b/app/assets/stylesheets/module/_owner_spaces-left.scss
@@ -1,0 +1,61 @@
+.spaces-left{
+  height: calc(100vh - 126px);
+  width: 235px;
+  border-right: 1px solid $super-light-gray;
+
+  @include linktext_darkgray();
+  overflow-y: scroll;
+
+  .title{
+    height: 80px;
+    text-align: center;
+    line-height: 80px;
+    color: $dark-gray;
+    border-bottom: 1px solid $super-light-gray;
+  }
+
+  .space{
+    @include clearfix();
+    height: 120px;
+    border-bottom: 1px solid $super-light-gray;
+
+    .space__image{
+      background-color: $light-gray;
+      height: 100px;
+      width: 100px;
+      margin: 10px 5px 0 10px;
+      float: left;
+    }
+
+    .space__name{
+      height: 100px;
+      width: 100px;
+      margin: 10px 10px 0 10px;
+      float: left;
+    }
+
+  }
+
+  .newspace{
+    height: 80px;
+    position: relative;
+    border-bottom: 1px solid $super-light-gray;
+
+    .newspace-btn{
+      background-color: $light-gray;
+      height: 60px;
+      width: 215px;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      margin: auto;
+      text-align: center;
+      line-height: 60px;
+      color: $white;
+      border-radius: 2px;
+    }
+  }
+
+}

--- a/app/views/owner_dashboards/index.html.haml
+++ b/app/views/owner_dashboards/index.html.haml
@@ -1,37 +1,4 @@
-%header#dashboard-header
-
-  .dashboard-header-inner-top
-    .dashboard-header-inner-top-inner
-      = link_to root_path do
-        .dashboard-header-inner-top-inner__logo
-          = image_tag 'logo_white_dashboard.png'
-      = link_to edit_user_registration_path do
-        .dashboard-header-inner-top-inner__menu_edit
-          登録情報編集
-      = link_to "/owners/#{current_user.id}/dashboard" do
-        .dashboard-header-inner-top-inner__menu_dashboard
-          スペース管理
-
-  .dashboard-header-inner-bottom
-    %ul.dashboard-header-inner-bottom-inner
-      .dashboard-header-inner-bottom-inner__currentuser
-        = current_user.name
-
-      = link_to edit_user_registration_path do
-        %li.dashboard-header-inner-bottom-inner__menu
-          設定
-      = link_to "https://www.google.co.jp/" do
-        %li.dashboard-header-inner-bottom-inner__menu
-          売上明細
-      = link_to "https://www.google.co.jp/" do
-        %li.dashboard-header-inner-bottom-inner__menu
-          スペース管理
-      = link_to "https://www.google.co.jp/" do
-        %li.dashboard-header-inner-bottom-inner__menu
-          予約一覧
-      = link_to "/owners/#{current_user.id}/dashboard" do
-        %li.dashboard-header-inner-bottom-inner__menu
-          ダッシュボード
+= render 'shared/owner_dashboard_header'
 
 %section.dashboard-content
   .dashboard-content-inner
@@ -54,4 +21,4 @@
         .dashboard-content__list-message
           完了した予約がn件あります。
 
-%footer#dashboard-footer
+= render 'shared/owner_dashboard_footer'

--- a/app/views/shared/_owner_dashboard_footer.html.haml
+++ b/app/views/shared/_owner_dashboard_footer.html.haml
@@ -1,0 +1,1 @@
+%footer#dashboard-footer

--- a/app/views/shared/_owner_dashboard_header.html.haml
+++ b/app/views/shared/_owner_dashboard_header.html.haml
@@ -1,0 +1,34 @@
+%header#dashboard-header
+
+  .dashboard-header-inner-top
+    .dashboard-header-inner-top-inner
+      = link_to root_path do
+        .dashboard-header-inner-top-inner__logo
+          = image_tag 'logo_white_dashboard.png'
+      = link_to edit_user_registration_path do
+        .dashboard-header-inner-top-inner__menu_edit
+          登録情報編集
+      = link_to "/owners/#{current_user.id}/dashboard" do
+        .dashboard-header-inner-top-inner__menu_dashboard
+          スペース管理
+
+  .dashboard-header-inner-bottom
+    %ul.dashboard-header-inner-bottom-inner
+      .dashboard-header-inner-bottom-inner__currentuser
+        = current_user.name
+
+      = link_to edit_user_registration_path do
+        %li.dashboard-header-inner-bottom-inner__menu
+          設定
+      = link_to "https://www.google.co.jp/" do
+        %li.dashboard-header-inner-bottom-inner__menu
+          売上明細
+      = link_to "/owners/#{current_user.id}/dashboard/spaces" do
+        %li.dashboard-header-inner-bottom-inner__menu
+          スペース一覧
+      = link_to "https://www.google.co.jp/" do
+        %li.dashboard-header-inner-bottom-inner__menu
+          予約一覧
+      = link_to "/owners/#{current_user.id}/dashboard" do
+        %li.dashboard-header-inner-bottom-inner__menu
+          ダッシュボード

--- a/app/views/spaces/index.html.haml
+++ b/app/views/spaces/index.html.haml
@@ -1,0 +1,31 @@
+= render 'shared/owner_dashboard_header'
+
+%section
+  .spaces-left
+    .title
+      会場一覧
+    .space__list
+      = link_to "https://www.google.co.jp/" do
+        .space
+          .space__image
+            画像表示
+          .space__name
+            スペース名
+      = link_to "https://www.google.co.jp/" do
+        .space
+          .space__image
+            画像表示
+          .space__name
+            スペース名
+      = link_to "https://www.google.co.jp/" do
+        .space
+          .space__image
+            画像表示
+          .space__name
+            スペース名
+    .newspace
+      = link_to "https://www.google.co.jp/" do
+        .newspace-btn
+          + スペースを追加
+
+= render 'shared/owner_dashboard_footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,7 @@ Rails.application.routes.draw do
   #オーナー用ダッシュボードトップ
   get 'owners/:user_id/dashboard'  =>  'owner_dashboards#index'
 
+  #オーナー用ダッシュボード space一覧画面
+  get 'owners/:user_id/dashboard/spaces'  =>  'spaces#index'
+
 end


### PR DESCRIPTION
# WHAT
オーナー用のダッシュボード画面にて、登録したスペースの一覧を見るための画面（spaces#index）を実装

# WHY
スペース管理に必要な機能のため

## 新規作成したルーティング
![2017-05-17 19 59 37](https://cloud.githubusercontent.com/assets/25572309/26150934/ac29aae8-3b3b-11e7-9bbc-c2af653abb9c.png)

## spaces#indexのビュー
![2017-05-17 20 02 20](https://cloud.githubusercontent.com/assets/25572309/26150962/c7574f46-3b3b-11e7-9c40-69c274dc83cb.png)
